### PR TITLE
Fix: correct gradle output name and harden run steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ steps:
 | go_project        | Found a Go project with file: go.mod                  |
 | node_js_project   | Found a Node.js project with file: package.json       |
 | maven_config      | Found a Maven project with file: pom.xml              |
-| gradel_config     | Found a Gradle project with file(s): settings.gradle* |
+| gradle_config     | Found a Gradle project with file(s): settings.gradle* |
 | tox_config        | Found a TOX configuration file: tox.ini               |
 | jupyter_notebooks | Found Jupyter Notebooks with file(s): *.ipynb         |
 | makefile          | Found a Makefile                                      |

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ outputs:
   maven_config:
     description: 'Repository contains Maven project with file: pom.xml'
     value: "${{ steps.content.outputs.maven_config }}"
-  gradel_config:
+  gradle_config:
     description: 'Repository contains Gradle project with file(s): settings.gradle*'
     value: "${{ steps.content.outputs.gradle_config }}"
   tox_config:

--- a/action.yaml
+++ b/action.yaml
@@ -73,10 +73,14 @@ runs:
         # Check repository content
 
         echo "Checking repository content in: '$PATH_PREFIX'"
-        cd "$PATH_PREFIX"
+        cd -- "$PATH_PREFIX" || {
+          echo "Error: failed to change directory to '$PATH_PREFIX' ❌"; exit 1
+        }
 
         # Always create a local text file containing the summary output
-        tmpfile=$(mktemp -p /tmp --suffix "github-summary-output.txt")
+        tmpfile=$(mktemp -p /tmp --suffix "github-summary-output.txt") || {
+          echo 'Error: failed to create temporary summary file ❌'; exit 1
+        }
         echo "tmpfile=$tmpfile" >> "$GITHUB_OUTPUT"
         # Check for Python project metadata files
         if [ -f pyproject.toml ] || [ -f setup.py ] || \
@@ -188,11 +192,13 @@ runs:
       env:
         TMPFILE: ${{ steps.content.outputs.tmpfile }}
       run: |
-        cat "$TMPFILE"  >> "$GITHUB_STEP_SUMMARY"
+        cat -- "$TMPFILE"  >> "$GITHUB_STEP_SUMMARY"
 
     - name: 'Remove temporary report/file'
       shell: bash
       env:
         TMPFILE: ${{ steps.content.outputs.tmpfile }}
       run: |
-        rm "$TMPFILE"
+        if [ -n "$TMPFILE" ]; then
+          rm -f -- "$TMPFILE"
+        fi

--- a/action.yaml
+++ b/action.yaml
@@ -56,24 +56,28 @@ runs:
   steps:
     - name: 'Check path_prefix is valid directory path'
       shell: bash
+      env:
+        PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Check path_prefix is valid directory path
-        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+        if [ ! -d "$PATH_PREFIX" ]; then
           echo 'Error: invalid path/prefix to project directory ❌'; exit 1
         fi
 
     - name: 'Check repository content'
       id: content
       shell: bash
+      env:
+        PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Check repository content
 
-        echo "Checking repository content in: '${{ inputs.path_prefix }}'"
-        cd "${{ inputs.path_prefix }}"
+        echo "Checking repository content in: '$PATH_PREFIX'"
+        cd "$PATH_PREFIX"
 
         # Always create a local text file containing the summary output
         tmpfile=$(mktemp -p /tmp --suffix "github-summary-output.txt")
-        echo "tmpfile=$tmpfile" >> "$GITHUB_ENV"
+        echo "tmpfile=$tmpfile" >> "$GITHUB_OUTPUT"
         # Check for Python project metadata files
         if [ -f pyproject.toml ] || [ -f setup.py ] || \
           [ -f Pipfile ] || [ -f requirements.txt ]; then
@@ -181,10 +185,14 @@ runs:
     - name: 'GitHub Summary Output'
       if: ${{ inputs.github_summary == 'true' }}
       shell: bash
+      env:
+        TMPFILE: ${{ steps.content.outputs.tmpfile }}
       run: |
-        cat "$tmpfile"  >> "$GITHUB_STEP_SUMMARY"
+        cat "$TMPFILE"  >> "$GITHUB_STEP_SUMMARY"
 
     - name: 'Remove temporary report/file'
       shell: bash
+      env:
+        TMPFILE: ${{ steps.content.outputs.tmpfile }}
       run: |
-        rm "${{ env.tmpfile }}"
+        rm "$TMPFILE"


### PR DESCRIPTION
## Summary

This PR contains two fixes for `action.yaml` (and the README).

### 1. Correct mislabelled output name (`gradel_config` → `gradle_config`)

The action declared an output named `gradel_config` (typo) while its
`value` mapped to `steps.content.outputs.gradle_config`. The declared
output name is corrected to `gradle_config` so the public name matches
the underlying step output, and the Outputs table in the README is
updated to match.

> [!NOTE]
> This renames the public output. Any downstream consumers referencing
> `gradel_config` must update to `gradle_config`.

### 2. Prevent template injection in composite run steps

zizmor flagged High-severity `template-injection` findings where
`inputs.path_prefix` expanded directly into composite `run:` blocks,
allowing code injection via attacker-controllable input. The input is
now passed through a `PATH_PREFIX` environment variable and referenced
as a quoted shell variable.

The summary temp file path (still created with `mktemp`) is now
published via `GITHUB_OUTPUT` instead of `GITHUB_ENV` and consumed
through a `TMPFILE` environment variable in later steps. This removes
the remaining `template-injection` finding on the cleanup step and the
`github-env` finding.

`zizmor action.yaml` now reports no findings.

## Commits

- `Fix: correct gradel_config output name to gradle_config`
- `Fix: prevent template injection in composite run steps`