### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -58,22 +58,22 @@ jobs:
         shell: bash
         run: |
           # Validate Action Output
-          if [ "${{ steps.testing.outputs.python_project }}" \
+          if [ "${STEPS_TESTING_OUTPUTS_PYTHON_PROJECT}" \
             != 'true' ]; then
             echo 'Error: expected to find a Python project ❌'
-            echo "Returned: ${{ steps.testing.outputs.python_project }}"
+            echo "Returned: ${STEPS_TESTING_OUTPUTS_PYTHON_PROJECT}"
             echo 'Expected: true'
             errors='true'
-          elif [ "${{ steps.testing.outputs.tox_config }}" \
+          elif [ "${STEPS_TESTING_OUTPUTS_TOX_CONFIG}" \
             != 'true' ]; then
             echo 'Error: expected to find a TOX configuration ❌'
-            echo "Returned: ${{ steps.testing.outputs.tox_config }}"
+            echo "Returned: ${STEPS_TESTING_OUTPUTS_TOX_CONFIG}"
             echo 'Expected: true'
             errors='true'
-          elif [ "${{ steps.testing.outputs.jupyter_notebooks }}" \
+          elif [ "${STEPS_TESTING_OUTPUTS_JUPYTER_NOTEBOOKS}" \
             != 'true' ]; then
             echo 'Error: expected to find Jupyter Notebooks ❌'
-            echo "Returned: ${{ steps.testing.outputs.jupyter_notebooks }}"
+            echo "Returned: ${STEPS_TESTING_OUTPUTS_JUPYTER_NOTEBOOKS}"
             echo 'Expected: true'
             errors='true'
           fi
@@ -83,3 +83,10 @@ jobs:
           else
             echo 'Action validation passed ✅'
           fi
+        env:
+          # yamllint disable-line rule:line-length
+          STEPS_TESTING_OUTPUTS_PYTHON_PROJECT: ${{ steps.testing.outputs.python_project }}
+          # yamllint disable-line rule:line-length
+          STEPS_TESTING_OUTPUTS_TOX_CONFIG: ${{ steps.testing.outputs.tox_config }}
+          # yamllint disable-line rule:line-length
+          STEPS_TESTING_OUTPUTS_JUPYTER_NOTEBOOKS: ${{ steps.testing.outputs.jupyter_notebooks }}


### PR DESCRIPTION
## Why

`zizmor`'s `template-injection` audit reports GitHub expressions that expand directly inside `run:` blocks. The expansion happens *before* the shell sees the script, so a value carrying shell syntax becomes code rather than data.

Each expression now reaches the shell through the step environment instead. These findings predate the change to the organisation `zizmor` floor (`low` → `informational`); they were simply below the old threshold.

## Please review the diff carefully

The transformation is not purely mechanical. Swapping `${{ expr }}` for `${VAR}` **changes the quoting rules**, because the original was substituted by GitHub before the shell ran and the replacement is an ordinary shell variable. Three contexts silently stop working:

| Context | Before | After |
| ------- | ------ | ----- |
| `var='${{ expr }}'` | substituted by GitHub | **literal string** |
| `echo 'text ${{ expr }}'` | substituted by GitHub | **literal string** |
| `cat <<'EOF'` … `${{ expr }}` | substituted by GitHub | **literal string** |

`shellcheck` catches the first two. **It does not catch the heredoc case.** That one was found in `url-validity-action`, where 27 references would have rendered the job summary as variable names instead of results.

## What was verified before raising this

- `zizmor --persona auditor --min-severity informational` — no findings
- `actionlint` (including shellcheck) — clean
- `yamllint` — clean
- A purpose-built audit for generated variables landing in single quotes or quoted heredocs — clean. It was validated by confirming it detects 33 such problems in the unrepaired output for `url-validity-action`.
- Diff restricted to workflow and action definitions; no `dependabot.yml` or version-pin comment changes rode along

## Note on the generated names

Where `zizmor`'s names push a line past the length limit, the line carries a `yamllint disable-line` directive. Shortening them was rejected: the short forms are unique only *within* one `env:` block, so a global rewrite merges distinct variables and leaves dangling references — verified by observing exactly that failure.
